### PR TITLE
Bug #23 - Update pdp gallery overlay to display one image instead of four

### DIFF
--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -223,13 +223,14 @@
 }
 
 /* gallery quad */
-.product-details.gallery-quad .pdp-carousel {
-  --flex-carousel: unset !important;
-}
-
 .product-details.gallery-quad .pdp-carousel > div:not(.pdp-carousel__wrapper),
 .product-details.gallery-quad .pdp-carousel > button {
   display: none;
+}
+
+.product-details.gallery-quad .pdp-overlay .pdp-carousel > div:not(.pdp-carousel__wrapper),
+.product-details.gallery-quad .pdp-overlay .pdp-carousel > button {
+  display: flex;
 }
 
 .product-details.gallery-quad .pdp-carousel--main-image-controls .pdp-carousel__wrapper {

--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -232,13 +232,12 @@
   display: none;
 }
 
-.product-details.gallery-quad .pdp-carousel__wrapper {
+.product-details.gallery-quad .pdp-carousel--main-image-controls .pdp-carousel__wrapper {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, 1fr);
   gap: 1rem;
   width: 100%;
-  /* overflow: visible; */
 }
 
 .product-details.gallery-quad .pdp-carousel__wrapper > .pdp-carousel__slide:nth-child(n+5) {
@@ -256,9 +255,14 @@
   border-radius: 8px;
 }
 
+.product-details.gallery-quad .pdp-overlay .pdp-carousel__slide > img {
+  max-height: inherit;
+}
+
 .product-details.gallery-quad .pdp-carousel__slide--horizontal {
   width: 100%;
 }
+
 
 /* pdp description */
 .pdp-description,

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -46,8 +46,6 @@ export default async function decorate(block) {
   let fragment;
   // PDP enhancements
   if (isFeatured) {
-    const body = document.querySelector('body');
-    body.classList.add('featured-pdp');
     block.classList.add('featured-pdp');
 
     // change fragment layout
@@ -301,6 +299,11 @@ export default async function decorate(block) {
     },
     { eager: true },
   );
+
+  if (isFeatured) {
+    const body = document.querySelector('body');
+    body.classList.add('featured-pdp');
+  }
 
   return Promise.resolve();
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #23 

Test URLs:
- Before: https://main--citisignal--aabsites.aem.live/
- After: https://bug-23--citisignal--aabsites.aem.live/


Reproduce steps:
1. Ensure that **carousel-layout** is set to **quad** in [DA](https://da.live/edit#/aabsites/citisignal/drafts/tlee/iphone-13). 
2. On the CitiSignal site, navigate to the PLP and select the "**Apple iPhone 13**" product.
2. Select an option to see the quad layout (2x2).
3. Click on any of the images and a single image should fill up the screen.
