### PR TITLE
fixed issue  all products navigate to iPhone 13 from PLP

### DIFF
--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -156,7 +156,7 @@ export async function getSkuFromUrl() {
     result = pathStr?.[3];
   }
   if (path.startsWith('/products/')) {
-    const pathStr = path.match(/\/products\/[\w|-]+\/(.+)$/);
+    const pathStr = path.match(/\/products\/(.+)$/);
     result = pathStr?.[1];
   }
   if (path.startsWith('/products/default')) {


### PR DESCRIPTION
changed getSkuFromUrl function as the product URL has changed to this format `/products/<SKU>`

Fix #59 

Test URLs:
- Before: https://main--citisignal--aabsites.aem.live/
- After: https://issue-59--citisignal--aabsites.aem.live/
